### PR TITLE
feat: add auto prerelease and release workflow

### DIFF
--- a/.github/workflows/unity-test-build-release.yaml
+++ b/.github/workflows/unity-test-build-release.yaml
@@ -1,0 +1,67 @@
+name: Unity Test Build Release
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Cache Library
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-${{ hashFiles('**/Packages/manifest.json') }}
+          restore-keys: Library-
+
+      - name: Build project
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          unityVersion: 6000.3.8f1
+          targetPlatform: StandaloneWindows64
+          buildsPath: build
+          buildName: CI-Build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Build-StandaloneWindows64
+          path: build/StandaloneWindows64
+
+  release:
+    needs: build
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Build-StandaloneWindows64
+          path: build/
+
+      - name: Zip build
+        run: zip -r CI-Build-Windows.zip build/
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event_name == 'pull_request' && format('prerelease-pr-{0}', github.event.pull_request.number) || format('release-{0}', github.sha) }}
+          name: ${{ github.event_name == 'pull_request' && format('Prerelease PR #{0}', github.event.pull_request.number) || format('Release {0}', github.sha) }}
+          prerelease: ${{ github.event_name == 'pull_request' }}
+          generate_release_notes: true
+          files: CI-Build-Windows.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Zmiany

Dodaje nowy plik `unity-test-build-release.yaml` z automatycznym prerelease i release.

### Jak działa:
- **PR → `dev`** — tylko build
- **PR → `main`** — build + prerelease
- **push → `main`** — build + release